### PR TITLE
Correction de l'hypothèse Juvin dans le dernier Elabe

### DIFF
--- a/presidentielle.json
+++ b/presidentielle.json
@@ -13131,7 +13131,7 @@
                 "erreur_inf": 0.3644
               },
               {
-                "candidat": "Michel Barnier",
+                "candidat": "Philippe Juvin",
                 "parti": ["Les Républicains"],
                 "intentions": 4,
                 "erreur_sup": 5.2518,


### PR DESCRIPTION
Philippe Juvin à la place Michel Barnier