### PR TITLE
fix hypothèse taubira coupée en 2

### DIFF
--- a/presidentielle.json
+++ b/presidentielle.json
@@ -29359,13 +29359,7 @@
                 "intentions": 12.5,
                 "erreur_sup": 14.508,
                 "erreur_inf": 10.492
-              }
-            ]
-          },
-          {
-            "hypothese": "Hypothèse Taubira candidate",
-            "sous_echantillon": 1042.107,
-            "candidats": [
+              },
               {
                 "candidat": "Jean-Luc Mélenchon",
                 "parti": ["France insoumise"],


### PR DESCRIPTION
L'hypothèse Taubira est séparée en 2 morceaux dans les données IFOP du 10/01, probablement une erreur de saisie